### PR TITLE
Fix typo in cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "volt"
-version = "2.0.3"
+version = "2.1.0"
 dependencies = [
  "ash",
  "libc",


### PR DESCRIPTION
Spotted a typo on the cargo.lock file. A simple one line fix!