### PR TITLE
Add Nix / NixOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,31 @@ There's an unofficial [volt-gui](https://aur.archlinux.org/packages/volt-gui) pa
 
 Read the `PKGBUILD` first. Not because of the packager, but because the AUR lets anyone submit anything.
 
+### NixOS
+
+The repository includes a flake for NixOS.
+
+To install it into your user profile:
+
+```sh
+nix profile install github:pythonlover02/volt-gui
+```
+
+For a flake setup, add volt-gui as an input:
+
+```nix
+inputs.volt-gui = {
+  url = "github:pythonlover02/volt-gui";
+  inputs.nixpkgs.follows = "nixpkgs";
+};
+```
+
+Then add the package through NixOS or Home Manager:
+
+```nix
+inputs.volt-gui.packages.${pkgs.system}.default
+```
+
 ### From source
 
 Every build target is a file, so make only rebuilds what changed. Everything lands under `build/`.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,6 @@ For a flake setup, add volt-gui as an input:
 ```nix
 inputs.volt-gui = {
   url = "github:pythonlover02/volt-gui";
-  inputs.nixpkgs.follows = "nixpkgs";
 };
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788316716,
+        "narHash": "sha256-bc7rSpXIdn9QWGNqfWcPZWOhEVF8NoeAZkWq0XWnf/k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3ed67ec0a4d3c7ab4ae1f04f8ee8df07bfa506a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "volt-src": "volt-src"
+      }
+    },
+    "volt-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1788426368,
+        "narHash": "sha256-KUne5KbziyADVtVSWBagOv0pes91Phmb6b5tpLafjOY=",
+        "owner": "pythonlover02",
+        "repo": "volt-gui",
+        "rev": "16e8e78b15d2a210257c3f23cb394b9b797da987",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pythonlover02",
+        "repo": "volt-gui",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -18,24 +18,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "volt-src": "volt-src"
-      }
-    },
-    "volt-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1788426368,
-        "narHash": "sha256-KUne5KbziyADVtVSWBagOv0pes91Phmb6b5tpLafjOY=",
-        "owner": "pythonlover02",
-        "repo": "volt-gui",
-        "rev": "16e8e78b15d2a210257c3f23cb394b9b797da987",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pythonlover02",
-        "repo": "volt-gui",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,206 @@
+{
+  description = "volt-gui - Vulkan game control panel";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    volt-src = {
+      url = "github:pythonlover02/volt-gui";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, volt-src }:
+    let
+      system = "x86_64-linux";
+
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+
+      lib = pkgs.lib;
+
+      cargoToml =
+        builtins.fromTOML
+          (builtins.readFile (volt-src + "/Cargo.toml"));
+
+      version = cargoToml.package.version;
+
+      commonRustArgs = {
+        pname = "volt";
+        inherit version;
+
+        src = volt-src;
+
+        cargoLock = {
+          lockFile = volt-src + "/Cargo.lock";
+        };
+
+        doCheck = false;
+      };
+
+      # 64-bit layer, launcher, and probe
+      volt64 = pkgs.rustPlatform.buildRustPackage (
+        commonRustArgs
+        // {
+          buildInputs = [
+            pkgs.libxcb
+          ];
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out/bin $out/lib
+
+            install -Dm755 \
+              "$(find target -type f -name volt -perm -0100 -print -quit)" \
+              $out/bin/volt
+
+            install -Dm755 \
+              "$(find target -type f -name volt-probe -perm -0100 -print -quit)" \
+              $out/bin/volt-probe
+
+            install -Dm755 \
+              "$(find target -type f -name libvolt.so -print -quit)" \
+              $out/lib/libvolt.so
+
+            runHook postInstall
+          '';
+        }
+      );
+
+      # 32-bit Vulkan layer
+      volt32 = pkgs.pkgsi686Linux.rustPlatform.buildRustPackage (
+        commonRustArgs
+        // {
+          pname = "volt-layer-32";
+
+          cargoBuildFlags = [
+            "--lib"
+          ];
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out/lib
+
+            install -Dm755 \
+              "$(find target -type f -name libvolt.so -print -quit)" \
+              $out/lib/libvolt.so
+
+            runHook postInstall
+          '';
+        }
+      );
+
+      pythonEnv = pkgs.python3.withPackages (ps: [
+        ps.pyside6
+      ]);
+
+      volt-gui = pkgs.stdenvNoCC.mkDerivation {
+        pname = "volt-gui";
+        inherit version;
+
+        src = volt-src;
+
+        nativeBuildInputs = [
+          pkgs.makeWrapper
+          pkgs.qt6.wrapQtAppsHook
+        ];
+
+        buildInputs = [
+          pkgs.qt6.qtbase
+          pkgs.qt6.qtwayland
+        ];
+
+        dontWrapQtApps = true;
+        dontConfigure = true;
+        dontBuild = true;
+
+        installPhase = ''
+          runHook preInstall
+
+          install -Dm755 \
+            ${volt64}/lib/libvolt.so \
+            $out/lib/volt/x86_64-linux-gnu/libvolt.so
+
+          install -Dm755 \
+            ${volt32}/lib/libvolt.so \
+            $out/lib/volt/i386-linux-gnu/libvolt.so
+
+          install -Dm644 \
+            VkLayer_volt.json \
+            $out/share/vulkan/implicit_layer.d/VkLayer_volt.json
+
+          mkdir -p $out/share/volt-gui
+          cp -r volt-gui/. $out/share/volt-gui/
+
+          install -Dm644 \
+            images/1.png \
+            $out/share/icons/hicolor/256x256/apps/volt-gui.png
+
+          mkdir -p $out/share/applications
+
+          cat > $out/share/applications/volt-gui.desktop <<EOF
+          [Desktop Entry]
+          Type=Application
+          Version=1.0
+          Name=volt-gui
+          Comment=Vulkan game control panel
+          Exec=volt-gui
+          Icon=volt-gui
+          Terminal=false
+          Categories=Utility;
+          Keywords=vulkan;vsync;gpu;gaming;
+          StartupNotify=true
+          StartupWMClass=volt-gui
+          EOF
+
+          # volt expects both layer directories on LD_LIBRARY_PATH.
+          makeWrapper ${volt64}/bin/volt $out/bin/volt \
+            --prefix LD_LIBRARY_PATH : \
+              "$out/lib/volt/x86_64-linux-gnu:$out/lib/volt/i386-linux-gnu" \
+            --prefix VK_ADD_IMPLICIT_LAYER_PATH : \
+              "$out/share/vulkan/implicit_layer.d"
+
+          # ash loads libvulkan dynamically.
+          makeWrapper ${volt64}/bin/volt-probe $out/bin/volt-probe \
+            --prefix LD_LIBRARY_PATH : \
+              "${lib.makeLibraryPath [ pkgs.vulkan-loader ]}"
+
+          makeWrapper ${pythonEnv}/bin/python $out/bin/volt-gui \
+            ''${qtWrapperArgs[@]} \
+            --prefix PATH : "$out/bin" \
+            --add-flags "$out/share/volt-gui/volt-gui.py"
+
+          runHook postInstall
+        '';
+
+        meta = {
+          description = "Control panel for Vulkan games on Linux";
+          homepage = "https://github.com/pythonlover02/volt-gui";
+          license = lib.licenses.gpl3Only;
+          platforms = [ "x86_64-linux" ];
+          mainProgram = "volt-gui";
+        };
+      };
+    in
+    {
+      packages.${system} = {
+        default = volt-gui;
+        volt-gui = volt-gui;
+      };
+
+      apps.${system} = {
+        default = {
+          type = "app";
+          program = "${volt-gui}/bin/volt-gui";
+        };
+
+        volt-gui = {
+          type = "app";
+          program = "${volt-gui}/bin/volt-gui";
+        };
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -3,14 +3,9 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-
-    volt-src = {
-      url = "github:pythonlover02/volt-gui";
-      flake = false;
-    };
   };
 
-  outputs = { self, nixpkgs, volt-src }:
+  outputs = { nixpkgs, ... }:
     let
       system = "x86_64-linux";
 
@@ -22,7 +17,7 @@
 
       cargoToml =
         builtins.fromTOML
-          (builtins.readFile (volt-src + "/Cargo.toml"));
+          (builtins.readFile ./Cargo.toml);
 
       version = cargoToml.package.version;
 
@@ -30,10 +25,10 @@
         pname = "volt";
         inherit version;
 
-        src = volt-src;
+        src = ./.;
 
         cargoLock = {
-          lockFile = volt-src + "/Cargo.lock";
+          lockFile = ./Cargo.lock;
         };
 
         doCheck = false;
@@ -101,7 +96,7 @@
         pname = "volt-gui";
         inherit version;
 
-        src = volt-src;
+        src = ./.;
 
         nativeBuildInputs = [
           pkgs.makeWrapper


### PR DESCRIPTION
Adds Nix / NixOS support for volt-gui.

The flake:

- builds both 64-bit and 32-bit Vulkan layers
- packages `volt`, `volt-probe`, and the GUI
- installs the Vulkan manifest, desktop entry, and icon

Also adds a NixOS install section to the README

Tested on x86_64 NixOS:

- `nix profile install` works
- declarative flake/Home Manager installation works
- `volt -- %command%` works as a Steam launch option
- the Vulkan layer loads and applies settings in-game